### PR TITLE
add mouse enter/leave callbacks to panel children

### DIFF
--- a/urutora/baseNode.lua
+++ b/urutora/baseNode.lua
@@ -153,6 +153,24 @@ function baseNode:action(f)
   return self
 end
 
+function baseNode:enter(f)
+  if type(f) == 'function' then
+    self.callback_enter = f
+  else
+    error('A function is required.')
+  end
+  return self
+end
+
+function baseNode:leave(f)
+  if type(f) == 'function' then
+    self.callback_leave = f
+  else
+    error('A function is required.')
+  end
+  return self
+end
+
 function baseNode:left()
   self.align = utils.alignments.LEFT
   return self
@@ -349,6 +367,16 @@ function baseNode:performMouseWheelAction(data)
       self.callback({ target = self, value = self.value })
     end
   end
+end
+
+function baseNode:performEnterAction()
+  if not self.enabled then return end
+  if self.callback_enter then self.callback_enter({ target = self }) end
+end
+
+function baseNode:performLeaveAction()
+  if not self.enabled then return end
+  if self.callback_leave then self.callback_leave({ target = self }) end
 end
 
 return baseNode

--- a/urutora/panel.lua
+++ b/urutora/panel.lua
@@ -306,7 +306,15 @@ function panel:update(dt)
 
   for _, node in pairs(self.children) do
     if node.enabled then
-      node.pointed = self.pointed and node:pointInsideNode(x, y) and not utils.isLabel(node)
+      local pointed = self.pointed and node:pointInsideNode(x, y) and not utils.isLabel(node)
+      if node.pointed ~= nil and pointed ~= node.pointed then
+        if pointed then
+          node:performEnterAction()
+        else
+          node:performLeaveAction()
+        end
+      end
+      node.pointed = pointed
       if node.update then node:update(dt) end
     end
   end


### PR DESCRIPTION
This allows to attach handler functions to UI elements that fire when mouse cursor enters/leaves them. Example usages: UI sound effects, playing animations on hover, etc.
Syntax:
```
button:enter(function(e)
  print('entered ' .. e.target.tag)
end)

button:leave(function(e)
  print('left ' .. e.target.tag)
end)
```